### PR TITLE
Add support for cron_expressions and custom target_tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.72.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+      - id: terraform_tflint
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 This terraform module is designed to help in using the AWS DLM Lifecycle. Each
 volume that needs to be supported by the DLM Lifecycle must be tagged with
-`Snapshot = "true"`.
-
-## Requirements
-
-* [AWS Terraform provider](https://www.terraform.io/docs/providers/aws/) >= 2.46
+the tags defined by variable `target_tags` (default `Snapshot = "true"`)
 
 ## Usage
 
@@ -15,27 +11,84 @@ module "dlm-lifecycle" {
   source = "julien-langlois/dlm-lifecycle-policies/aws"
 
   dlm_policies = [
-    { description = "DLM7", snapshot_name = "Rolling backup 7 days", start_time = "01:00", interval_hours = 4, retention_count = 7 },
-    { description = "DLM14", snapshot_name = "Rolling backup 14 days", start_time = "04:00", interval_hours = 12, retention_count = 14 },
-    { description = "DLM30", snapshot_name = "Rolling backup 30 days", start_time = "21:00", interval_hours = 2, retention_count = 30 }
+    {
+      description = "DLM7"
+      snapshot_name = "Rolling backup 7 days"
+      start_time = "01:00"
+      interval_hours = 4
+      retention_count = 7
+    },
+    {
+      description = "DLM14"
+      snapshot_name = "Rolling backup 14 days"
+      start_time = "04:00"
+      interval_hours = 12
+      retention_count = 14
+    },
+    {
+      description = "DLM30"
+      snapshot_name = "Rolling backup 30 days"
+      start_time = "21:00"
+      interval_hours = 2
+      retention_count = 30
+    },
+    {
+      description = "DLM40"
+      resource_types  = "INSTANCE"
+      snapshot_name = "WeeklyBackupAMI"
+      cron_expression = "cron(0 3 * * SUN *)" # Every Sunday 3am
+      retention_count = 15
+      target_tags = {
+        Name = "instance-example"
+        Snapshot = "DLM40"
+      }
+    },
+    }
   ]
 }
 ```
 
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.54.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dlm_lifecycle_policy.policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dlm_lifecycle_policy) | resource |
+| [aws_iam_role.dlm_lifecycle_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.dlm_lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+
 ## Inputs
 
-| Name          | Description                                                   |       Type        |     Default     | Required |
-| ------------- | ------------------------------------------------------------- | :---------------: | :-------------: | :------: |
-| unique\_name  | Enter Unique Name to identify the Terraform Stack (lowercase) |      string       |      `v1`       |    no    |
-| stack\_prefix | Stack Prefix for resource generation                          |      string       | `dlm_lifecycle` |    no    |
-| dlm\_policies | Policies to be created                                        | list(map(string)) |       ""        |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_dlm_policies"></a> [dlm\_policies](#input\_dlm\_policies) | DLM Policies to be created | <pre>list(object({<br>    description     = string<br>    state           = optional(string, "ENABLED")<br>    resource_types  = optional(string, "VOLUME")<br>    snapshot_name   = optional(string, "")<br>    cron_expression = optional(string, null)<br>    start_time      = optional(string, "03:00")<br>    interval_hours  = optional(number, 24)<br>    interval_unit   = optional(string, "HOURS")<br>    retention_count = optional(number, 7)<br>    target_tags     = optional(map(string), { Snapshot = "true" })<br>    copy_tags       = optional(bool, false)<br>  }))</pre> | n/a | yes |
+| <a name="input_stack_prefix"></a> [stack\_prefix](#input\_stack\_prefix) | Stack Prefix for resource generation | `string` | `"dlm_lifecycle"` | no |
+| <a name="input_unique_name"></a> [unique\_name](#input\_unique\_name) | Enter Unique Name to identify the Terraform Stack (lowercase) | `string` | `"v1"` | no |
 
 ## Outputs
 
-| Name | Description                                            |
-| ---- | ------------------------------------------------------ |
-| arn  | Amazon Resource Name (ARN) of the DLM Lifecycle Policy |
-| id   | Identifier of the DLM Lifecycle Policy                 |
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | Identifier of the DLM Lifecycle Policy |
+| <a name="output_policies_arns"></a> [policies\_arns](#output\_policies\_arns) | Amazon Resource Name (ARN) of the DLM Lifecycle Policy |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Related documentation
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_id"></a> [id](#output\_id) | Identifier of the DLM Lifecycle Policy |
-| <a name="output_policies_arns"></a> [policies\_arns](#output\_policies\_arns) | Amazon Resource Name (ARN) of the DLM Lifecycle Policy |
+| <a name="output_arns"></a> [arns](#output\_arns) | Amazon Resource Name (ARN) of the DLM Lifecycle Policy |
+| <a name="output_ids"></a> [ids](#output\_ids) | Identifier of the DLM Lifecycle Policy |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Related documentation

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module "dlm-lifecycle" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46.0 |
 
 ## Providers

--- a/main.tf
+++ b/main.tf
@@ -12,33 +12,31 @@ resource "aws_iam_role_policy" "dlm_lifecycle" {
 resource "aws_dlm_lifecycle_policy" "policies" {
   count = length(var.dlm_policies)
 
-  description        = lookup(var.dlm_policies[count.index], "description", "Snapshot Lifecycle Policy ${count.index}")
+  description        = var.dlm_policies[count.index]["description"]
   execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
-  state              = lookup(var.dlm_policies[count.index], "state", "ENABLED")
+  state              = var.dlm_policies[count.index]["state"]
 
   policy_details {
-    resource_types = [lookup(var.dlm_policies[count.index], "resource_types", "VOLUME")]
+    resource_types = [var.dlm_policies[count.index]["resource_types"]]
     schedule {
-      name = lookup(var.dlm_policies[count.index], "snapshot_name", "Schedule ${count.index}")
+      name = coalesce(var.dlm_policies[count.index]["snapshot_name"], var.dlm_policies[count.index]["description"])
 
       create_rule {
-        cron_expression = lookup(var.dlm_policies[count.index], "cron_expression", null)
-        interval        = var.dlm_policies[count.index]["cron_expression"] != null ? null : lookup(var.dlm_policies[count.index], "interval_hours", 24)
+        cron_expression = var.dlm_policies[count.index]["cron_expression"]
+        interval        = var.dlm_policies[count.index]["cron_expression"] != null ? null : var.dlm_policies[count.index]["interval_hours"]
         interval_unit   = var.dlm_policies[count.index]["cron_expression"] != null ? null : "HOURS"
-        times           = var.dlm_policies[count.index]["cron_expression"] != null ? null : [lookup(var.dlm_policies[count.index], "start_time", "03:00")]
+        times           = var.dlm_policies[count.index]["cron_expression"] != null ? null : [var.dlm_policies[count.index]["start_time"]]
       }
 
       retain_rule {
-        count = lookup(var.dlm_policies[count.index], "retention_count", 7)
+        count = var.dlm_policies[count.index]["retention_count"]
       }
       tags_to_add = {
         SnapshotCreator = "DLM"
       }
-      copy_tags = lookup(var.dlm_policies[count.index], "copy_tags", false)
+      copy_tags = var.dlm_policies[count.index]["copy_tags"]
     }
 
-    target_tags = {
-      Snapshot = "true"
-    }
+    target_tags = var.dlm_policies[count.index]["target_tags"]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -22,10 +22,12 @@ resource "aws_dlm_lifecycle_policy" "policies" {
       name = lookup(var.dlm_policies[count.index], "snapshot_name", "Schedule ${count.index}")
 
       create_rule {
-        interval      = lookup(var.dlm_policies[count.index], "interval_hours", 24)
-        interval_unit = "HOURS"
-        times         = [lookup(var.dlm_policies[count.index], "start_time", "03:00")]
+        cron_expression = lookup(var.dlm_policies[count.index], "cron_expression", null)
+        interval        = var.dlm_policies[count.index]["cron_expression"] != null ? null : lookup(var.dlm_policies[count.index], "interval_hours", 24)
+        interval_unit   = var.dlm_policies[count.index]["cron_expression"] != null ? null : "HOURS"
+        times           = var.dlm_policies[count.index]["cron_expression"] != null ? null : [lookup(var.dlm_policies[count.index], "start_time", "03:00")]
       }
+
       retain_rule {
         count = lookup(var.dlm_policies[count.index], "retention_count", 7)
       }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
-output "policies_arns" {
+output "arns" {
   description = "Amazon Resource Name (ARN) of the DLM Lifecycle Policy"
   value       = aws_dlm_lifecycle_policy.policies[*].arn
 }
 
-output "id" {
+output "ids" {
   description = "Identifier of the DLM Lifecycle Policy"
   value       = aws_dlm_lifecycle_policy.policies[*].id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
-output "arn" {
+output "policies_arns" {
   description = "Amazon Resource Name (ARN) of the DLM Lifecycle Policy"
-  value       = aws_dlm_lifecycle_policy.policies.*.arn
+  value       = aws_dlm_lifecycle_policy.policies[*].arn
 }
 
 output "id" {
   description = "Identifier of the DLM Lifecycle Policy"
-  value       = aws_dlm_lifecycle_policy.policies.*.id
+  value       = aws_dlm_lifecycle_policy.policies[*].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,5 +12,17 @@ variable "stack_prefix" {
 
 variable "dlm_policies" {
   description = "DLM Policies to be created"
-  type        = list(map(string))
+  type = list(object({
+    description     = string
+    state           = optional(string, "ENABLED")
+    resource_types  = optional(string, "VOLUME")
+    snapshot_name   = optional(string, "")
+    cron_expression = optional(string, null)
+    start_time      = optional(string, "03:00")
+    interval_hours  = optional(number, 24)
+    interval_unit   = optional(string, "HOURS")
+    retention_count = optional(number, 7)
+    target_tags     = optional(map(string), { Snapshot = "true" })
+    copy_tags       = optional(bool, false)
+  }))
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = ">= 2.46.0"
   }


### PR DESCRIPTION
# Description

This is a breaking change. It has to be released as a major version.
Optional variables are used here they were introduced in terraform 1.3.0
See [here](https://github.com/hashicorp/terraform/releases/tag/v1.3.0) for details

- outputs renamed to match best practices
- `description` is now a required variable
- `snapshot_name` will be set as `description` if no value is pass
- pre-commit added for linter
- Docs updates and more examples of usage for `cron-expression` and `target_tags`